### PR TITLE
base on openjdk:8-slim, install nodejs and yarn from official apt sources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ENV PATH=${PATH}:${ANDROID_NDK}
 # install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ant \
+        apt-transport-https \
         autoconf \
         automake \
         curl \
@@ -43,9 +44,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip
 
 # install nodejs and yarn packages from nodesource and yarn apt sources
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+RUN echo "deb https://deb.nodesource.com/node_10.x stretch main" > /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb https://dl.yarnpkg.com/debian/ stable main" > tee /etc/apt/sources.list.d/yarn.list \
+    && curl -sS https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
     && apt get install -y --no-install-recommends nodejs yarn
 
 # download buck

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/ubuntu:16.04
+FROM debian:stretch-slim
 
 LABEL Description="This image provides a base Android development environment for React Native, and may be used to run tests."
 LABEL maintainer="Héctor Ramos <hector@fb.com>"
@@ -23,14 +23,31 @@ ENV ANDROID_NDK=/opt/ndk/android-ndk-r$NDK_VERSION
 ENV PATH=${PATH}:${ANDROID_NDK}
 
 # install system dependencies
-RUN apt-get update && apt-get install ant autoconf automake curl g++ gcc git libqt5widgets5 lib32z1 lib32stdc++6 make maven npm openjdk-8* python-dev python3-dev qml-module-qtquick-controls qtdeclarative5-dev unzip -y
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ant \
+        autoconf \
+        automake \
+        curl \
+        g++ \
+        gcc \
+        git \
+        libqt5widgets5 \
+        lib32z1 \
+        lib32stdc++6 \
+        make \
+        maven \
+        openjdk-8-jdk-headless \
+        python-dev \
+        python3-dev \
+        qml-module-qtquick-controls \
+        qtdeclarative5-dev \
+        unzip
 
-# configure npm && install node, yarn
-RUN npm config set spin=false && \
-    npm config set progress=false && \
-    npm install n -g && \
-    n $NODE_VERSION && \
-    npm i -g yarn
+# install nodejs and yarn packages from nodesource and yarn apt sources
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+    && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt get install -y --no-install-recommends nodejs yarn
 
 # download buck
 RUN git clone https://github.com/facebook/buck.git /opt/buck --branch $BUCK_VERSION --depth=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,14 +41,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3-dev \
         qml-module-qtquick-controls \
         qtdeclarative5-dev \
-        unzip
+        unzip \
+        rm -rf /var/lib/apt/lists/*
 
 # install nodejs and yarn packages from nodesource and yarn apt sources
 RUN echo "deb https://deb.nodesource.com/node_10.x stretch main" > /etc/apt/sources.list.d/nodesource.list \
-    && echo "deb https://dl.yarnpkg.com/debian/ stable main" > tee /etc/apt/sources.list.d/yarn.list \
+    && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
     && curl -sS https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-    && apt get install -y --no-install-recommends nodejs yarn
+    && apt-get update \
+    && apt-get install -y --no-install-recommends nodejs yarn \
+    && rm -rf /var/lib/apt/lists/*
 
 # download buck
 RUN git clone https://github.com/facebook/buck.git /opt/buck --branch $BUCK_VERSION --depth=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         g++ \
         gcc \
         git \
+        gnupg2 \
         libqt5widgets5 \
         lib32z1 \
         lib32stdc++6 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         qml-module-qtquick-controls \
         qtdeclarative5-dev \
         unzip \
-        rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*;
 
 # install nodejs and yarn packages from nodesource and yarn apt sources
 RUN echo "deb https://deb.nodesource.com/node_10.x stretch main" > /etc/apt/sources.list.d/nodesource.list \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM openjdk:8-slim
 
 LABEL Description="This image provides a base Android development environment for React Native, and may be used to run tests."
 LABEL maintainer="Héctor Ramos <hector@fb.com>"
@@ -13,7 +13,6 @@ ARG NODE_VERSION=lts
 ARG WATCHMAN_VERSION=4.9.0
 
 # set default environment variables
-ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 ENV ADB_INSTALL_TIMEOUT=10
 ENV PATH=${PATH}:/opt/buck/bin/
 ENV ANDROID_HOME=/opt/android
@@ -36,7 +35,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         lib32stdc++6 \
         make \
         maven \
-        openjdk-8-jdk-headless \
         python-dev \
         python3-dev \
         qml-module-qtquick-controls \


### PR DESCRIPTION
base Docker image on openjdk:8-slim, which is based on debian:stretch-slim. Then install nodejs and yarn packages from official apt sources.

also make apt package installation more readable.

NOTES: JAVA_HOME is set in openjdk8-slim, so removing it