### PR TITLE
simplify and reduce Android SDK setup stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN curl -sS -L https://github.com/facebook/buck/releases/download/v${BUCK_VERSI
 RUN curl -sS https://dl.google.com/android/repository/${SDK_VERSION} -o /tmp/sdk.zip \
     && mkdir ${ANDROID_HOME} \
     && unzip -q -d ${ANDROID_HOME} /tmp/sdk.zip \
-    && rm /tmp/sdk.zip
+    && rm /tmp/sdk.zip \
     && yes | sdkmanager --licenses \
     && yes | sdkmanager "platform-tools" \
         "emulator" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,19 +56,13 @@ RUN curl -sS -L https://github.com/facebook/buck/releases/download/v${BUCK_VERSI
 # Full reference at https://dl.google.com/android/repository/repository2-1.xml
 # download and unpack android
 RUN curl -sS https://dl.google.com/android/repository/${SDK_VERSION} -o /tmp/sdk.zip \
-    && mkdir /opt/android \
-    && unzip -q -d /opt/android /tmp/sdk.zip \
+    && mkdir ${ANDROID_HOME} \
+    && unzip -q -d ${ANDROID_HOME} /tmp/sdk.zip \
     && rm /tmp/sdk.zip
-
-
-# Add android SDK tools
-RUN cd ~ && mkdir ~/.android && echo '### User Sources for Android SDK Manager' > ~/.android/repositories.cfg \
     && yes | sdkmanager --licenses \
     && yes | sdkmanager "platform-tools" \
         "emulator" \
         "platforms;android-$ANDROID_BUILD_VERSION" \
         "build-tools;$ANDROID_TOOLS_VERSION" \
-        "add-ons;addon-google_apis-google-23" \
-        "system-images;android-19;google_apis;armeabi-v7a" \
-        "extras;android;m2repository" \
-    && sdkmanager --update
+        "system-images;android-19;default;armeabi-v7a" \
+        "extras;android;m2repository"


### PR DESCRIPTION
after some play, I found that sdkmanager --update is unnecessary, but also we could reduce image layer combining SDK download and setup steps. Also RN don't need Google APIs, so removed it.