### PR TITLE
remove Android SDK 28

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL Description="This image provides a base Android development environment fo
 # set default build arguments
 ARG SDK_VERSION=sdk-tools-linux-4333796.zip
 ARG ANDROID_BUILD_VERSION=29
-ARG ANDROID_TOOLS_VERSION=29.0.2
+ARG ANDROID_TOOLS_VERSION=29.0.3
 ARG BUCK_VERSION=2019.10.17.01
 ARG NDK_VERSION=20.0.5594570
 ARG NODE_VERSION=12.x
@@ -74,9 +74,7 @@ RUN curl -sS https://dl.google.com/android/repository/${SDK_VERSION} -o /tmp/sdk
     && yes | sdkmanager --licenses \
     && yes | sdkmanager "platform-tools" \
         "emulator" \
-        "platforms;android-28" \
         "platforms;android-$ANDROID_BUILD_VERSION" \
-        "build-tools;28.0.3" \
         "build-tools;$ANDROID_TOOLS_VERSION" \
         "add-ons;addon-google_apis-google-23" \
         "system-images;android-19;google_apis;armeabi-v7a" \


### PR DESCRIPTION
# Summary

In https://github.com/facebook/react-native/commit/214d73b5a28fd09ab06764d636ff145de90c975c, React Native switched to SDK 29. So mission accomplished, and there is no need to keep multiple versions of SDK, which will add-up to image size and slow down CI.

Also bumped Android Build Tools to 29.0.3.

People who need SDK 28 will be using old version of the image.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
