### PR TITLE
add ruby bundler by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
         python \
         openssh-client \
         unzip \
+    && gem install bundler \
     && rm -rf /var/lib/apt/lists/*;
 
 # install nodejs and yarn packages from nodesource and yarn apt sources


### PR DESCRIPTION
Fix https://github.com/react-native-community/docker-android/issues/75