### PR TITLE
android-21 system image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN curl -sS https://dl.google.com/android/repository/${SDK_VERSION} -o /tmp/sdk
         "build-tools;$ANDROID_TOOLS_VERSION" \
         "add-ons;addon-google_apis-google-23" \
         "cmake;3.10.2.4988404" \
-        "system-images;android-19;google_apis;armeabi-v7a" \
+        "system-images;android-21;google_apis;armeabi-v7a" \
         "extras;android;m2repository" \
         "ndk;$NDK_VERSION" \
     && rm -rf ${ANDROID_HOME}/.android


### PR DESCRIPTION
RN is dropping Android 4.x and will support API 21+ in https://github.com/facebook/react-native/commit/a17ff44adcf003dd4e4ef2301e1f80b77913f712