### PR TITLE
publish release to Docker Hub

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-20.04
+    env:
+      DOCKER_IMAGE: reactnativecommunity/react-native-android
+    if: ${{ startsWith(github.ref, 'refs/tags/v*') }}
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -20,10 +23,14 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Prepare tags
+        id: tags
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo ::set-output name=tags::"${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:latest"
+
       - name: Push to Docker Hub
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: |
-            reactnativecommunity/react-native-android:latest
-            reactnativecommunity/react-native-android:${{ GITHUB_REF }}
+          tags: ${{ steps.tags.outputs.tags }}


### PR DESCRIPTION
Tag version of a release will be used as docker image tag, and must start with **v**, for example v2020-10-26. Publish action won't run if tag ref doesn't start with v.

FYI, after some investigation I found that **$GITHUB_REF** cannot be used as tag, so I parsed out version from GITHUB_REF and used it as tag.

closes https://github.com/react-native-community/docker-android/issues/86

