### PR TITLE
JAVA_HOME is missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ ENV ANDROID_HOME=/opt/android
 ENV ANDROID_SDK_HOME=${ANDROID_HOME}
 ENV ANDROID_NDK=${ANDROID_HOME}/ndk/$NDK_VERSION
 ENV ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/$NDK_VERSION
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 ENV PATH=${ANDROID_NDK}:${ANDROID_HOME}/cmdline-tools/tools/bin:${ANDROID_HOME}/emulator:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:/opt/buck/bin/:${PATH}
 


### PR DESCRIPTION
JAVA_HOME was missing from the env vars in the latest release casuing: https://app.circleci.com/pipelines/github/facebook/react-native/6860/workflows/8d2c4b81-2e3e-48cb-8c9e-3d405adecd28/jobs/173860/parallel-runs/0/steps/0-113 to fail