### PR TITLE
remove ANDROID_SDK_HOME, ANDROID_NDK_HOME env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,7 @@ ARG WATCHMAN_VERSION=4.9.0
 # set default environment variables
 ENV ADB_INSTALL_TIMEOUT=10
 ENV ANDROID_HOME=/opt/android
-ENV ANDROID_SDK_HOME=${ANDROID_HOME}
 ENV ANDROID_NDK=${ANDROID_HOME}/ndk/$NDK_VERSION
-ENV ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/$NDK_VERSION
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 ENV PATH=${ANDROID_NDK}:${ANDROID_HOME}/cmdline-tools/tools/bin:${ANDROID_HOME}/emulator:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:/opt/buck/bin/:${PATH}


### PR DESCRIPTION
When NDK is used in the image, there is ANDROID_NDK_HOME deprecation warning. And found that it's not correct to point ANDROID_SDK_HOME to ANDROID_HOME, because they serve different purposes. Please skim into https://developer.android.com/studio/command-line/variables