### PR TITLE
remove m2repository, add-ons

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,5 @@ RUN curl -sS https://dl.google.com/android/repository/${SDK_VERSION} -o /tmp/sdk
         "add-ons;addon-google_apis-google-23" \
         "cmake;3.10.2.4988404" \
         "system-images;android-21;google_apis;armeabi-v7a" \
-        "extras;android;m2repository" \
         "ndk;$NDK_VERSION" \
     && rm -rf ${ANDROID_HOME}/.android

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,6 @@ RUN curl -sS https://dl.google.com/android/repository/${SDK_VERSION} -o /tmp/sdk
         "emulator" \
         "platforms;android-$ANDROID_BUILD_VERSION" \
         "build-tools;$ANDROID_TOOLS_VERSION" \
-        "add-ons;addon-google_apis-google-23" \
         "cmake;3.10.2.4988404" \
         "system-images;android-21;google_apis;armeabi-v7a" \
         "ndk;$NDK_VERSION" \


### PR DESCRIPTION
**m2repository** is local maven repository for Android Support Library, which is deprecated in favor of AndroidX, and RN switched to AndroidX a while ago. It takes 381M storage. 

also removing **addon-google_apis-google-23** which include following libraries, that are not used in RN. It takes ~1M.
- com.google.android.maps=maps.jar;API for Google Maps
- com.android.future.usb.accessory=usb.jar;API for USB Accessories
- com.google.android.media.effects=effects.jar;Collection of video effects
