### PR TITLE
v2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,9 @@ jobs:
         - name: Build Docker image
           run: docker build --tag $IMAGE_TAG .
 
+        - name: Check if Emulator (Headless) starts
+          run: docker run --rm -v "${GITHUB_WORKSPACE}/scripts/":/scripts $IMAGE_TAG /bin/sh -c "/scripts/test-emulator-headless.sh"
+
         - name: Checkout React Native
           uses: actions/checkout@v2
           with:
@@ -29,6 +32,4 @@ jobs:
             path: react-native
 
         - name: Build React Native
-          run: |
-            docker run --rm -v "${GITHUB_WORKSPACE}/react-native/":/pwd -w /pwd $IMAGE_TAG /bin/sh -c \
-            "yarn install && ./gradlew --no-daemon :packages:rn-tester:android:app:assembleRelease && ./scripts/circleci/buck_fetch.sh"
+          run: docker run --rm -v "${GITHUB_WORKSPACE}/scripts/":/scripts -v "${GITHUB_WORKSPACE}/react-native/":/react-native -w /react-native $IMAGE_TAG /bin/sh -c "/scripts/test-react-native-setup.sh"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,11 +24,13 @@ jobs:
       - name: Prepare tags
         env:
           DOCKER_IMAGE: reactnativecommunity/react-native-android
+          STABLE_MAJOR: 1
         id: tags
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
-          TAGS="$DOCKER_IMAGE:$VERSION,$DOCKER_IMAGE:$(echo $VERSION | cut -d'.' -f 1)"
-          if [[ $VERSION == "1*" ]]; then
+          MAJOR=$(echo $VERSION | cut -d'.' -f 1)
+          TAGS="$DOCKER_IMAGE:$VERSION,$DOCKER_IMAGE:$MAJOR"
+          if [[ $MAJOR == $STABLE_MAJOR ]]; then
             TAGS="$TAGS,$DOCKER_IMAGE:latest"
           fi
           echo ::set-output name=tags::${TAGS}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,11 @@ jobs:
         id: tags
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
-          echo ::set-output name=tags::"${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:latest"
+          TAGS="$DOCKER_IMAGE:$VERSION"
+          if [[ $VERSION == 1* ]];
+            TAGS="$TAGS,$DOCKER_IMAGE:latest"
+          fi
+          echo ::set-output name=tags::${TAGS}
 
       - name: Build & publish to Docker Hub
         uses: docker/build-push-action@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
         id: tags
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
-          TAGS="$DOCKER_IMAGE:$VERSION"
+          TAGS="$DOCKER_IMAGE:$VERSION,$DOCKER_IMAGE:$(echo $VERSION | cut -d'.' -f 1)"
           if [[ $VERSION == "1*" ]]; then
             TAGS="$TAGS,$DOCKER_IMAGE:latest"
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
           TAGS="$DOCKER_IMAGE:$VERSION"
-          if [[ $VERSION == 1* ]];
+          if [[ $VERSION == "1*" ]]; then
             TAGS="$TAGS,$DOCKER_IMAGE:latest"
           fi
           echo ::set-output name=tags::${TAGS}

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ ENV PATH=${ANDROID_NDK}:${ANDROID_HOME}/cmdline-tools/tools/bin:${ANDROID_HOME}/
 # Install system dependencies
 RUN apt update -qq && apt install -qq -y --no-install-recommends \
         apt-transport-https \
+        build-essential \
         curl \
         file \
         git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
         python3 \
         python3-distutils \
         rsync \
+        tzdata \
         unzip \
     && rm -rf /var/lib/apt/lists/*;
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ ENV ADB_INSTALL_TIMEOUT=10
 ENV ANDROID_HOME=/opt/android
 ENV ANDROID_SDK_HOME=${ANDROID_HOME}
 ENV ANDROID_NDK=${ANDROID_HOME}/ndk/$NDK_VERSION
-ENV ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/$NDK_VERSION
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 ENV PATH=${ANDROID_NDK}:${ANDROID_HOME}/cmdline-tools/tools/bin:${ANDROID_HOME}/emulator:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:/opt/buck/bin/:${PATH}
@@ -27,7 +26,6 @@ ENV PATH=${ANDROID_NDK}:${ANDROID_HOME}/cmdline-tools/tools/bin:${ANDROID_HOME}/
 RUN apt update -qq && apt install -qq -y --no-install-recommends \
         apt-transport-https \
         curl \
-        build-essential \
         file \
         git \
         gnupg2 \
@@ -39,10 +37,7 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
         python3 \
         python3-distutils \
         rsync \
-        ruby \
-        ruby-dev \
         unzip \
-    && gem install bundler \
     && rm -rf /var/lib/apt/lists/*;
 
 # install nodejs and yarn packages from nodesource and yarn apt sources

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,14 +30,17 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
         build-essential \
         file \
         git \
-        cmake \
-        ruby-full \
-        openjdk-8-jdk \
         gnupg2 \
-        python \
-        python3-distutils \
+        libc++1-10 \
+        libgl1 \
+        libtcmalloc-minimal4 \
+        openjdk-8-jdk-headless \
         openssh-client \
+        python3 \
+        python3-distutils \
         rsync \
+        ruby \
+        ruby-dev \
         unzip \
     && gem install bundler \
     && rm -rf /var/lib/apt/lists/*;

--- a/scripts/test-emulator-headless.sh
+++ b/scripts/test-emulator-headless.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+echo no | avdmanager create avd -n testEmulator -k "system-images;android-21;google_apis;armeabi-v7a"
+emulator -avd testEmulator -no-audio -no-cache -no-snapshot -no-window &
+
+echo "Waiting until the device is ready"
+adb wait-for-device
+
+echo "The device is ready"
+adb shell input keyevent 82

--- a/scripts/test-emulator-headless.sh
+++ b/scripts/test-emulator-headless.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 echo no | avdmanager create avd -n testEmulator -k "system-images;android-21;google_apis;armeabi-v7a"
 emulator -avd testEmulator -no-audio -no-cache -no-snapshot -no-window &
 

--- a/scripts/test-react-native-setup.sh
+++ b/scripts/test-react-native-setup.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 echo "Check Buck setup"
 ./scripts/circleci/buck_fetch.sh
 buck build ReactAndroid/src/main/java/com/facebook/react

--- a/scripts/test-react-native-setup.sh
+++ b/scripts/test-react-native-setup.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+echo "Check Buck setup"
+./scripts/circleci/buck_fetch.sh
+buck build ReactAndroid/src/main/java/com/facebook/react
+buck build ReactAndroid/src/main/java/com/facebook/react/shell
+
+echo "Build React Native"
+yarn install
+./gradlew --no-daemon :ReactAndroid:packageReactNdkLibsForBuck
+
+echo "Assemble RNTester app"
+./gradlew --no-daemon :packages:rn-tester:android:app:assembleRelease


### PR DESCRIPTION
I would like to make purpose of the image clear and install required packages.
- build React Native
- build React Native apps/libraries

So I would like to propose some breaking changes and v2:
- remove python version 2. Buck no longer requires it. Will save more than 20MB
- headless jdk. we're saving around 114 MB because we don't install many fonts and libraries required to run emulator in UI mode. Anyone can use the image as base, and install full jdk.
- remove cmake (apt): we save around 75.3 MB, nevertheless we'll install cmake using sdkmanager
- remove ruby. Maybe we can provide another image with fastlane.

Also updated publish job to update latest tag only if version 1.x published. We can change that when we're sure that v2 is stable.

**NOTE: created v1 branch**