### PR TITLE
remove ruby-full

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,8 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
         python3 \
         python3-distutils \
         rsync \
-        ruby-full \
+        ruby \
+        ruby-dev \
         tzdata \
         unzip \
     && rm -rf /var/lib/apt/lists/*;


### PR DESCRIPTION
remove ruby-full, install ruby and ruby-dev instead. ruby-full include ri or documentation package, which makes ruby package installation slow by generating documentations.