### PR TITLE
compiler tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,14 +25,15 @@ ENV PATH=${ANDROID_NDK}:${ANDROID_HOME}/cmdline-tools/tools/bin:${ANDROID_HOME}/
 # Install system dependencies
 RUN apt update -qq && apt install -qq -y --no-install-recommends \
         apt-transport-https \
-        build-essential \
         curl \
         file \
         git \
+        g++ \
         gnupg2 \
         libc++1-10 \
         libgl1 \
         libtcmalloc-minimal4 \
+        make \
         openjdk-8-jdk-headless \
         openssh-client \
         python3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
         apt-transport-https \
         curl \
         file \
+        gcc \
         git \
         g++ \
         gnupg2 \


### PR DESCRIPTION
build-essential installs dpkg-dev in addition to compiler tools, which depends on perl and other tools used to build Debian packages. g++ install gcc, and this change will install gcc, g++, make tools. We would save 70MB.