### PR TITLE
add zip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
         ruby-dev \
         tzdata \
         unzip \
+        zip \
     && rm -rf /var/lib/apt/lists/*;
 
 # install nodejs and yarn packages from nodesource and yarn apt sources


### PR DESCRIPTION
It seems that React Native codegen uses zip and it's failing https://app.circleci.com/pipelines/github/facebook/react-native/7041/workflows/789a107d-1759-4b24-be42-0e966e8f7f9f/jobs/175931