### PR TITLE
Proposal: split image, add what react native versions are supported and use debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM debian:10.7
 
 LABEL Description="This image provides a base Android development environment for React Native, and may be used to run tests."
 
@@ -18,7 +18,7 @@ ENV ADB_INSTALL_TIMEOUT=10
 ENV ANDROID_HOME=/opt/android
 ENV ANDROID_SDK_HOME=${ANDROID_HOME}
 ENV ANDROID_NDK=${ANDROID_HOME}/ndk/$NDK_VERSION
-ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+ENV JAVA_HOME=/opt/jdk8u275-b01
 
 ENV PATH=${ANDROID_NDK}:${ANDROID_HOME}/cmdline-tools/tools/bin:${ANDROID_HOME}/emulator:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:/opt/buck/bin/:${PATH}
 
@@ -31,11 +31,10 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
         git \
         g++ \
         gnupg2 \
-        libc++1-10 \
+        libc++1-7 \
         libgl1 \
         libtcmalloc-minimal4 \
         make \
-        openjdk-8-jdk-headless \
         openssh-client \
         python3 \
         python3-distutils \
@@ -47,6 +46,13 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
         zip \
     && rm -rf /var/lib/apt/lists/*;
 
+# install java according to https://adoptopenjdk.net/installation.html?variant=openjdk8&jvmVariant=hotspot#x64_linux-jdk
+# TODO: verify download
+RUN curl -sL https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u275-b01/OpenJDK8U-jdk_x64_linux_hotspot_8u275b01.tar.gz  -o /tmp/java.tar.gz \
+    && tar xzf /tmp/java.tar.gz -C /opt/ \
+    && rm /tmp/java.tar.gz \
+    && export PATH=/opt/jdk8u275-b01/bin:$PATH
+
 # install nodejs and yarn packages from nodesource and yarn apt sources
 RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION} | bash - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
@@ -57,7 +63,7 @@ RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION} | bash - \
 
 # download and install buck using debian package
 RUN curl -sS -L https://github.com/facebook/buck/releases/download/v${BUCK_VERSION}/buck.${BUCK_VERSION}_all.deb -o /tmp/buck.deb \
-    && dpkg -i /tmp/buck.deb \
+    && dpkg --force-all -i /tmp/buck.deb \
     && rm /tmp/buck.deb
 
 # Full reference at https://dl.google.com/android/repository/repository2-1.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,83 +1,44 @@
-FROM debian:10.7
+FROM reactnativecommunity:react-native-android-core:android-29-jdk-8
 
 LABEL Description="This image provides a base Android development environment for React Native, and may be used to run tests."
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 # set default build arguments
-ARG SDK_VERSION=commandlinetools-linux-6609375_latest.zip
-ARG ANDROID_BUILD_VERSION=29
-ARG ANDROID_TOOLS_VERSION=29.0.3
 ARG BUCK_VERSION=2020.10.21.01
-ARG NDK_VERSION=20.1.5948944
-ARG NODE_VERSION=14.x
-ARG WATCHMAN_VERSION=4.9.0
 
-# set default environment variables
-ENV ADB_INSTALL_TIMEOUT=10
-ENV ANDROID_HOME=/opt/android
-ENV ANDROID_SDK_HOME=${ANDROID_HOME}
-ENV ANDROID_NDK=${ANDROID_HOME}/ndk/$NDK_VERSION
-ENV JAVA_HOME=/opt/jdk8u275-b01
-
-ENV PATH=${ANDROID_NDK}:${ANDROID_HOME}/cmdline-tools/tools/bin:${ANDROID_HOME}/emulator:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:/opt/buck/bin/:${PATH}
+ENV PATH=${ANDROID_HOME}/emulator:/opt/buck/bin/:${PATH}
 
 # Install system dependencies
 RUN apt update -qq && apt install -qq -y --no-install-recommends \
-        apt-transport-https \
-        curl \
         file \
-        gcc \
-        git \
-        g++ \
         gnupg2 \
         libc++1-7 \
         libgl1 \
         libtcmalloc-minimal4 \
-        make \
         openssh-client \
+        python-minimal \
         python3 \
         python3-distutils \
         rsync \
         ruby \
         ruby-dev \
         tzdata \
-        unzip \
         zip \
     && rm -rf /var/lib/apt/lists/*;
 
-# install java according to https://adoptopenjdk.net/installation.html?variant=openjdk8&jvmVariant=hotspot#x64_linux-jdk
-# TODO: verify download
-RUN curl -sL https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u275-b01/OpenJDK8U-jdk_x64_linux_hotspot_8u275b01.tar.gz  -o /tmp/java.tar.gz \
-    && tar xzf /tmp/java.tar.gz -C /opt/ \
-    && rm /tmp/java.tar.gz \
-    && export PATH=/opt/jdk8u275-b01/bin:$PATH
-
-# install nodejs and yarn packages from nodesource and yarn apt sources
-RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION} | bash - \
-    && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
-    && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-    && apt-get update -qq \
-    && apt-get install -qq -y --no-install-recommends nodejs yarn \
-    && rm -rf /var/lib/apt/lists/*
-
-# download and install buck using debian package
+# # download and install buck using debian package
 RUN curl -sS -L https://github.com/facebook/buck/releases/download/v${BUCK_VERSION}/buck.${BUCK_VERSION}_all.deb -o /tmp/buck.deb \
     && dpkg --force-all -i /tmp/buck.deb \
     && rm /tmp/buck.deb
 
-# Full reference at https://dl.google.com/android/repository/repository2-1.xml
-# download and unpack android
+# # Full reference at https://dl.google.com/android/repository/repository2-1.xml
+# # download and unpack android
 RUN curl -sS https://dl.google.com/android/repository/${SDK_VERSION} -o /tmp/sdk.zip \
     && mkdir -p ${ANDROID_HOME}/cmdline-tools \
     && unzip -q -d ${ANDROID_HOME}/cmdline-tools /tmp/sdk.zip \
     && rm /tmp/sdk.zip \
     && yes | sdkmanager --licenses \
-    && yes | sdkmanager "platform-tools" \
-        "emulator" \
-        "platforms;android-$ANDROID_BUILD_VERSION" \
-        "build-tools;$ANDROID_TOOLS_VERSION" \
-        "cmake;3.10.2.4988404" \
+    && yes | sdkmanager "emulator" \
         "system-images;android-21;google_apis;armeabi-v7a" \
-        "ndk;$NDK_VERSION" \
     && rm -rf ${ANDROID_HOME}/.android

--- a/Dockerfile.core
+++ b/Dockerfile.core
@@ -1,0 +1,60 @@
+# to be published as 
+FROM adoptopenjdk/openjdk8:debian
+
+LABEL Description="This image provides a base Android development environment for React Native."
+LABEL JAVA="OpenJDK8"
+LABEL ANDROID_SDK="29"
+LABEL ANDROID_TOOLS="29.0.3"
+LABEL NODE="14"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# set default build arguments
+ARG SDK_VERSION=commandlinetools-linux-6609375_latest.zip
+ARG ANDROID_BUILD_VERSION=29
+ARG ANDROID_TOOLS_VERSION=29.0.3
+ARG NDK_VERSION=20.1.5948944
+ARG NODE_VERSION=14.x
+ARG WATCHMAN_VERSION=4.9.0
+
+# set default environment variables
+ENV ADB_INSTALL_TIMEOUT=10
+ENV ANDROID_HOME=/opt/android
+ENV ANDROID_SDK_HOME=${ANDROID_HOME}
+ENV ANDROID_NDK=${ANDROID_HOME}/ndk/$NDK_VERSION
+
+ENV PATH=${ANDROID_NDK}:${ANDROID_HOME}/cmdline-tools/tools/bin:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${PATH}
+
+# Install system dependencies
+RUN apt update -qq && apt install -qq -y --no-install-recommends \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        g++ \
+        gcc \
+        git \
+        make \
+        unzip \
+    && rm -rf /var/lib/apt/lists/*;
+
+# install nodejs and yarn packages from nodesource and yarn apt sources
+RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION} | bash - \
+    && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
+    && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && apt update -qq \
+    && apt install -qq -y --no-install-recommends python2.7 nodejs yarn \
+    && rm -rf /var/lib/apt/lists/*
+
+# Full reference at https://dl.google.com/android/repository/repository2-1.xml
+# download and unpack android
+RUN curl -sS https://dl.google.com/android/repository/${SDK_VERSION} -o /tmp/sdk.zip \
+    && mkdir -p ${ANDROID_HOME}/cmdline-tools \
+    && unzip -q -d ${ANDROID_HOME}/cmdline-tools /tmp/sdk.zip \
+    && rm /tmp/sdk.zip \
+    && yes | sdkmanager --licenses \
+    && yes | sdkmanager "platform-tools" \
+        "platforms;android-$ANDROID_BUILD_VERSION" \
+        "build-tools;$ANDROID_TOOLS_VERSION" \
+        "cmake;3.10.2.4988404" \
+        "ndk;$NDK_VERSION" \
+    && rm -rf ${ANDROID_HOME}/.android

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+
+run-core:
+	docker build -f Dockerfile.core --tag debian-react-native:android-29-jdk-8 .
+	docker run --rm -ti debian-react-native:android-29-jdk-8
+
+run:
+	docker build --tag react-native-android:3.0 .
+	docker run --rm -ti react-native-android:3.0

--- a/README.md
+++ b/README.md
@@ -7,10 +7,41 @@
 ## Motivation
 This is an implementation of https://github.com/react-native-community/discussions-and-proposals/blob/master/proposals/0005-Official-Docker.md.
 
+## Support
+
+### reactnativecommunity/react-native-android
+
+Full image to build and test React Native apps. Comes with:
+
+* Node
+* Npm & Yarn
+* Android SDK
+* Buck
+* Python,
+* Ruby
+* Commonly used apt packages (unzip, zip, ...)
+
+| React Native Versions  | Full image                                    
+| ---------------------- | -----------
+| x - 0.63               | reactnativecommunity/react-native-android:3.0
+
+[Find on docker hub.](https://hub.docker.com/r/reactnativecommunity/react-native-android/)
+
+# reactnativecommunity/react-native-android-core
+
+Core image that contains the minimum to build React Native apps. Comes with:
+
+* Node
+* Npm & Yarn
+* Android SDK
+
+| React Native Versions  | Core image
+| ---------------------- | -----------
+| x - 0.63               | reactnativecommunity/react-native-android-core:android-29-jdk-8 
+
+[Find on docker hub.](https://hub.docker.com/r/reactnativecommunity/react-native-android-core/)
+
 ## Showcase
 https://github.com/react-native-community/ci-sample
-
-## Dockerhub Image
-see https://hub.docker.com/r/reactnativecommunity/react-native-android/
 
 Original version is split from react-native repo, see https://github.com/facebook/react-native/blob/988366a4179d87d667e5d9396efdfba4cbbe0b2e/ContainerShip/Dockerfile.android-base.


### PR DESCRIPTION
This proposal contains 3 major changes.

## Update readme

I've updated the readme so that it's clear what React Native versions build on what docker image. Once a new React Native versions targets the Android SDK 30 it will be important to publish a new version and make this clear to the users.

## Split image

The main image (react-native-android) contains many packages that might not be needed for everyone. Therefor I suggest to maintain 2 images. A core images that has just the minimum to build apps, and the full image (which is opiniated) and adds Buck, Python, Ruby and some handy apt packages.

### Core image

I would make use of the tags to to tell what Android target SDK is included and what Java JDK version. The first core image is reactnativecommunity/react-native-android-core:android-29-jdk-8. When React Native supports Android 30, a second core image should be made, that has SDK 30.

## Debian

Debian Buster (10.7) isn't as up to data as Ubuntu, but it's very stable and well used.

## Caveats

Using Debian actually lowers the Ruby version of 2.6 to 2.5. A solution would be to use rbenv instead.