### PR TITLE
fix: yarn key expiration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,9 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
         zip \
     && rm -rf /var/lib/apt/lists/*;
 
+# Refresh keys to prevent invalid signature 
+RUN apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com
+
 # install nodejs and yarn packages from nodesource and yarn apt sources
 RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION} | bash - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \


### PR DESCRIPTION
An error occured when the yarn GPG key used to sign packages passed its expiry date.
So refresh keys to prevent this kind of error.

```
W: GPG error: https://dl.yarnpkg.com/debian stable InRelease: The following signatures were invalid: EXPKEYSIG 23E7166788B63E1E Yarn Packaging <yarn@dan.cx>
E: The repository 'https://dl.yarnpkg.com/debian stable InRelease' is not signed.
```

See https://github.com/yarnpkg/yarn/issues/7866#issuecomment-586581740 