### PR TITLE
add JDK 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
         libtcmalloc-minimal4 \
         make \
         openjdk-8-jdk-headless \
+        openjdk-11-jdk-headless \
         openssh-client \
         patch \
         python3 \


### PR DESCRIPTION
JDK 11 is required by Android Gradle Plugin 7, JAVA_HOME still points to JDK 8