### PR TITLE
Bump JDK version to 11 and build Buck from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ ARG ANDROID_TOOLS_VERSION=30.0.3
 ARG BUCK_VERSION=2021.01.12.01
 ARG NDK_VERSION=21.4.7075529
 ARG NODE_VERSION=14.x
+ARG WATCHMAN_VERSION=4.9.0
 
 # set default environment variables, please don't remove old env for compatibilty issue
 ENV ADB_INSTALL_TIMEOUT=10

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ ARG ANDROID_TOOLS_VERSION=30.0.3
 ARG BUCK_VERSION=2021.01.12.01
 ARG NDK_VERSION=21.4.7075529
 ARG NODE_VERSION=14.x
-ARG WATCHMAN_VERSION=4.9.0
 
 # set default environment variables, please don't remove old env for compatibilty issue
 ENV ADB_INSTALL_TIMEOUT=10

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV ANDROID_HOME=/opt/android
 ENV ANDROID_SDK_HOME=${ANDROID_HOME}
 ENV ANDROID_SDK_ROOT=${ANDROID_HOME}
 ENV ANDROID_NDK=${ANDROID_HOME}/ndk/$NDK_VERSION
-ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 ENV ANT_OPTS="-Xmx4096m"
 
 ENV PATH=${ANDROID_NDK}:${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/emulator:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:/opt/buck/bin/:${PATH}
@@ -38,7 +38,7 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
         libgl1 \
         libtcmalloc-minimal4 \
         make \
-        openjdk-8-jdk-headless \
+        openjdk-11-jdk-headless \
         openssh-client \
         patch \
         python2 \
@@ -78,8 +78,8 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
 # install buck by compiling it from source
 RUN git clone --depth 1 --branch v${BUCK_VERSION} https://github.com/facebook/buck.git
 RUN cd buck && ant
-RUN cd buck && ./bin/buck build --show-output buck
-ENV PATH="./buck/bin/:${PATH}"
+RUN cd buck && ./bin/buck build --config java.target_level=11 --config java.source_level=11 --show-output buck
+ENV PATH="/buck/bin/:${PATH}"
 
 # install nodejs and yarn packages from nodesource
 RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION} | bash - \

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,11 +75,15 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
     && gem install bundler \
     && rm -rf /var/lib/apt/lists/*;
 
-# install buck by compiling it from source
-RUN git clone --depth 1 --branch v${BUCK_VERSION} https://github.com/facebook/buck.git
-RUN cd buck && ant
-RUN cd buck && ./bin/buck build --config java.target_level=11 --config java.source_level=11 --show-output buck
-ENV PATH="/buck/bin/:${PATH}"
+# install buck by compiling it from source. We also remove the buck repo once it's built.
+RUN git clone --depth 1 --branch v${BUCK_VERSION} https://github.com/facebook/buck.git \
+    && cd buck \
+    && ant \
+    && mkdir /buck-compiled \
+    && cp -r bin config programs python-dsl ant-out third-party /buck-compiled \
+    && cd .. \
+    && rm -rf buck
+ENV PATH="/buck-compiled/bin/:${PATH}"
 
 # install nodejs and yarn packages from nodesource
 RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION} | bash - \


### PR DESCRIPTION
This PR is updating the Docker image to work correctly with only JDK 11.
Specifically I had to move Buck to be built from source inside the container instead of using the `.deb` package (as that is not JDK 11 compatible).

This should ideally unblock `react-native` migration to Java 11, AGP 7.x and Android 12.