### PR TITLE
build buck from source and JDK 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt update  && apt install  -y --no-install-recommends \
     ant \
     git \
     openjdk-11-jdk-headless \
-    python2
+    python3
 # install buck by compiling it from source. We also remove the buck repo once it's built.
 RUN git clone --depth 1 --branch v${BUCK_VERSION} https://github.com/facebook/buck.git \
     && cd buck \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,8 @@ RUN apt update  && apt install  -y --no-install-recommends \
     ant \
     git \
     openjdk-11-jdk-headless \
-    python2 \
     python-setuptools \
-    python3
+    python3-setuptools
 # install buck by compiling it from source. We also remove the buck repo once it's built.
 RUN git clone --depth 1 --branch v${BUCK_VERSION} https://github.com/facebook/buck.git \
     && cd buck \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN apt update  && apt install  -y --no-install-recommends \
     ant \
     git \
     openjdk-11-jdk-headless \
-    python3
+    python3 \
+    python-is-python3
 # install buck by compiling it from source. We also remove the buck repo once it's built.
 RUN git clone --depth 1 --branch v${BUCK_VERSION} https://github.com/facebook/buck.git \
     && cd buck \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt update  && apt install  -y --no-install-recommends \
     git \
     openjdk-11-jdk-headless \
     python2 \
+    python-setuptools \
     python3
 # install buck by compiling it from source. We also remove the buck repo once it's built.
 RUN git clone --depth 1 --branch v${BUCK_VERSION} https://github.com/facebook/buck.git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN apt update  && apt install  -y --no-install-recommends \
     ant \
     git \
     openjdk-11-jdk-headless \
-    python3 \
-    python-is-python3
+    python2 \
+    python3
 # install buck by compiling it from source. We also remove the buck repo once it's built.
 RUN git clone --depth 1 --branch v${BUCK_VERSION} https://github.com/facebook/buck.git \
     && cd buck \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt update  && apt install  -y --no-install-recommends \
 RUN git clone --depth 1 --branch v${BUCK_VERSION} https://github.com/facebook/buck.git \
     && cd buck \
     && ant \
-    && ./bin/buck build buck --out /tmp/buck.pex
+    && ./bin/buck build buck --config java.target_level=11 --config java.source_level=11 --out /tmp/buck.pex
 
 # build react native image and use buck built from source from above stage
 FROM ubuntu:20.04


### PR DESCRIPTION
Build buck from source and use JDK 11, this will make possible to bump Android Gradle Plugin to 7.x.