### PR TITLE
remove ANDROID_SDK_HOME env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ ARG WATCHMAN_VERSION=4.9.0
 # set default environment variables, please don't remove old env for compatibilty issue
 ENV ADB_INSTALL_TIMEOUT=10
 ENV ANDROID_HOME=/opt/android
-ENV ANDROID_SDK_HOME=${ANDROID_HOME}
 ENV ANDROID_SDK_ROOT=${ANDROID_HOME}
 ENV ANDROID_NDK=${ANDROID_HOME}/ndk/$NDK_VERSION
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64


### PR DESCRIPTION
remove ANDROID_SDK_HOME env variable, AGP 7 is complaining about it.