### PR TITLE
Cleanup Dockerfile after API 31 bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,6 @@ LABEL Description="This image provides a base Android development environment fo
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# old versions to make sure build pass before RN versions are bumped
-ARG ANDROID_BUILD_VERSION_deprecated=30
-ARG ANDROID_TOOLS_VERSION_deprecated=30.0.3
-
 # set default build arguments
 ARG SDK_VERSION=commandlinetools-linux-7302050_latest.zip
 ARG ANDROID_BUILD_VERSION=31
@@ -112,9 +108,7 @@ RUN curl -sS https://dl.google.com/android/repository/${SDK_VERSION} -o /tmp/sdk
     && yes | sdkmanager "platform-tools" \
         "emulator" \
         "platforms;android-$ANDROID_BUILD_VERSION" \
-        "platforms;android-$ANDROID_BUILD_VERSION_deprecated" \
         "build-tools;$ANDROID_TOOLS_VERSION" \
-        "build-tools;$ANDROID_TOOLS_VERSION_deprecated" \
         "cmake;3.18.1" \
         "system-images;android-21;google_apis;armeabi-v7a" \
         "ndk;$NDK_VERSION" \


### PR DESCRIPTION
Removes API 30 tools used for compatibility with the main repo.