### PR TITLE
Migrate to supported ubuntu image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 
 defaults: &defaults
-  machine: true
+  machine: ubuntu-2004:202201-02
   working_directory: ~/project
 
 aliases:
@@ -12,7 +12,6 @@ aliases:
       docker run --rm --name rn-env react-native-community/react-native bin/sh -c "npx envinfo"
 
 jobs:
-
   deploy:
     <<: *defaults
     steps:


### PR DESCRIPTION
CircleCI emailed mentioning that the machine image specified here is deprecated.

Following [migration guide here](https://circleci.com/docs/2.0/images/linux-vm/14.04-to-20.04-migration/?mkt_tok=NDg1LVpNSC02MjYAAAGCnda0p48GNPJwISlPnjtti3fRhw_aY0m4E19TBXrogtuInTcQmxjSEVaj_d-pIhquKzaEGHLW2hYHkdFGP5MiLxthtI_xwdfV_zj4k3WAtOSB#changes)
There are some notable changes to the new image as [mentioned here](https://circleci.com/docs/2.0/images/linux-vm/14.04-to-20.04-migration/?mkt_tok=NDg1LVpNSC02MjYAAAGCnda0p48GNPJwISlPnjtti3fRhw_aY0m4E19TBXrogtuInTcQmxjSEVaj_d-pIhquKzaEGHLW2hYHkdFGP5MiLxthtI_xwdfV_zj4k3WAtOSB#change-to-ubuntu). Figured this PR might start that conversation?