### PR TITLE
Add CMake 3.10.2 to the Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,7 @@ RUN curl -sS https://dl.google.com/android/repository/${SDK_VERSION} -o /tmp/sdk
         "emulator" \
         "platforms;android-$ANDROID_BUILD_VERSION" \
         "build-tools;$ANDROID_TOOLS_VERSION" \
-        "cmake;3.10.2" \
+        "cmake;3.10.2.4988404" \
         "cmake;3.18.1" \
         "system-images;android-21;google_apis;armeabi-v7a" \
         "ndk;$NDK_VERSION" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,6 +109,7 @@ RUN curl -sS https://dl.google.com/android/repository/${SDK_VERSION} -o /tmp/sdk
         "emulator" \
         "platforms;android-$ANDROID_BUILD_VERSION" \
         "build-tools;$ANDROID_TOOLS_VERSION" \
+        "cmake;3.10.2" \
         "cmake;3.18.1" \
         "system-images;android-21;google_apis;armeabi-v7a" \
         "ndk;$NDK_VERSION" \

--- a/scripts/test-react-native-setup.sh
+++ b/scripts/test-react-native-setup.sh
@@ -2,12 +2,16 @@
 
 set -e
 
-echo "Check Buck setup"
+export KOTLIN_HOME="ReactAndroid/src/main/third-party/kotlin"
+
+echo "Download Buck dependencies"
 ./scripts/circleci/buck_fetch.sh
+
+echo "Build React Native via Buck"
 buck build ReactAndroid/src/main/java/com/facebook/react
 buck build ReactAndroid/src/main/java/com/facebook/react/shell
 
-echo "Build React Native"
+echo "Build React Native via Gradle"
 yarn install
 ./gradlew --no-daemon :ReactAndroid:packageReactNdkLibsForBuck
 

--- a/scripts/test-react-native-setup.sh
+++ b/scripts/test-react-native-setup.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-export KOTLIN_HOME="ReactAndroid/src/main/third-party/kotlin"
+export KOTLIN_HOME="third-party/kotlin"
 
 echo "Download Buck dependencies"
 ./scripts/circleci/buck_fetch.sh


### PR DESCRIPTION
Building Hermes inside RN currently requires CMake 3.10.2 which is missing from this image