### PR TITLE
Add `libicu-dev` to the list of the installed libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,8 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
         sudo \
         ninja-build \
         zip \
+        # Dev libraries requested by Hermes
+        libicu-dev \
         # Emulator & video bridge dependencies
         libc6 \
         libdbus-1-3 \


### PR DESCRIPTION
Hermes needs `libicu-dev` in order to build correctly, otherwise the build can not be configured correctly. I'm adding it to the list of installed libraries.