### PR TITLE
fix: permission for non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,4 +117,5 @@ RUN curl -sS https://dl.google.com/android/repository/${SDK_VERSION} -o /tmp/sdk
         "system-images;android-21;google_apis;armeabi-v7a" \
         "ndk;$NDK_VERSION" \
     && rm -rf ${ANDROID_HOME}/.android \
+    && chmod 777 -R /opt/android \
     && ln -s ${ANDROID_NDK}/toolchains/llvm/prebuilt/linux-x86_64/lib64/clang/9.0.9 ${ANDROID_NDK}/toolchains/llvm/prebuilt/linux-x86_64/lib64/clang/9.0.8


### PR DESCRIPTION
For non-root user in docker
```
License for package Android SDK Build-Tools 29.0.2 accepted.
Preparing "Install Android SDK Build-Tools 29.0.2 (revision: 29.0.2)".
Warning: Failed to read or create install properties file.

FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':app:compileDebugJavaWithJavac'.
> Failed to install the following SDK components:
      build-tools;29.0.2 Android SDK Build-Tools 29.0.2
  The SDK directory is not writable (/opt/android)
```