### PR TITLE
feat: Add `jq` and `shellcheck` to the docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ defaults: &defaults
 aliases:
   - &build-docker
     name: Build Docker Image
+    no_output_timeout: 20m
     command: |
       docker build -t react-native-community/react-native .
       docker run --rm --name rn-env react-native-community/react-native bin/sh -c "npx envinfo"

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,9 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
         libgl1 \
         pulseaudio \
         socat \
+        # Dev dependencies required by linters
+        jq \
+        shellcheck \
     && gem install bundler \
     && rm -rf /var/lib/apt/lists/*;
 


### PR DESCRIPTION
CI on React Native is flaky due to us trying to reinstall those dependencies over and over in the `analyze_pr` step. Let's install them in the container as they're quite small:

https://packages.ubuntu.com/bionic/shellcheck
https://packages.ubuntu.com/bionic/jq