### PR TITLE
Install 3.2.2 Ruby via rbenv.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ aliases:
     no_output_timeout: 20m
     command: |
       docker build -t react-native-community/react-native .
+      docker run --rm --name rb-env react-native-community/react-native bin/sh -c "ruby --version; bundle --version"
       docker run --rm --name rn-env react-native-community/react-native bin/sh -c "npx envinfo"
 
 jobs:
@@ -31,9 +32,6 @@ jobs:
     steps:
       - checkout
       - run: *build-docker
-      - run:
-          name: Check Ruby installation
-          command: docker run --rm --name rn-env react-native-community/react-native bin/sh -c "ruby --version; bundle --version"
       - run:
           name: Checkout React Native
           command: git clone https://github.com/facebook/react-native.git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,9 @@ jobs:
       - checkout
       - run: *build-docker
       - run:
+          name: Check Ruby installation
+          command: docker run /bin/sh -c "ruby --version; bundle --version"
+      - run:
           name: Checkout React Native
           command: git clone https://github.com/facebook/react-native.git
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
       - run: *build-docker
       - run:
           name: Check Ruby installation
-          command: docker run /bin/sh -c "ruby --version; bundle --version"
+          command: docker run --rm --name rn-env react-native-community/react-native bin/sh -c "ruby --version; bundle --version"
       - run:
           name: Checkout React Native
           command: git clone https://github.com/facebook/react-native.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,8 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
         ninja-build \
         zip \
         # Dev dependencies required by Ruby
+        libtool \
+        libyaml-dev \
         libz-dev \
         # Dev libraries requested by Hermes
         libicu-dev \
@@ -64,7 +66,7 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
 RUN git clone https://github.com/rbenv/rbenv.git ${RBENV_PATH} \
     && git clone https://github.com/rbenv/ruby-build.git ${RBENV_PATH}/plugins/ruby-build \
     && eval "$(${RBENV_PATH}/bin/rbenv init -)" \
-    && CONFIGURE_OPTS="--disable-install-doc" rbenv install $RUBY_VERSION \
+    && rbenv install $RUBY_VERSION \
     && rbenv global $RUBY_VERSION \
     && gem install bundler
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,8 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
         sudo \
         ninja-build \
         zip \
+        # Dev dependencies required by Ruby
+        libz-dev \
         # Dev libraries requested by Hermes
         libicu-dev \
         # Dev dependencies required by linters

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,6 @@ ENV CMAKE_BIN_PATH=${ANDROID_HOME}/cmake/$CMAKE_VERSION/bin
 
 ENV PATH=${RBENV_PATH}/shims:${CMAKE_BIN_PATH}:${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/emulator:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${PATH}
 
-# Disable documentation for Ruby
-ENV RUBY_CONFIGURE_OPTS=--disable-install-doc
-
 # Install system dependencies
 RUN apt update -qq && apt install -qq -y --no-install-recommends \
         apt-transport-https \
@@ -67,7 +64,7 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
 RUN git clone https://github.com/rbenv/rbenv.git ${RBENV_PATH} \
     && git clone https://github.com/rbenv/ruby-build.git ${RBENV_PATH}/plugins/ruby-build \
     && eval "$(${RBENV_PATH}/bin/rbenv init -)" \
-    && rbenv install $RUBY_VERSION \
+    && CONFIGURE_OPTS="--disable-install-doc" rbenv install $RUBY_VERSION \
     && rbenv global $RUBY_VERSION \
     && gem install bundler
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG WATCHMAN_VERSION=4.9.0
 ARG CMAKE_VERSION=3.22.1
 
 # set default environment variables, please don't remove old env for compatibilty issue
-ENV RBENV_PATH=/root/.rbenv
+ENV RBENV_ROOT=/root/.rbenv
 ENV ADB_INSTALL_TIMEOUT=10
 ENV ANDROID_HOME=/opt/android
 ENV ANDROID_SDK_ROOT=${ANDROID_HOME}
@@ -25,7 +25,7 @@ ENV ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/$NDK_VERSION
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 ENV CMAKE_BIN_PATH=${ANDROID_HOME}/cmake/$CMAKE_VERSION/bin
 
-ENV PATH=${RBENV_PATH}/shims:${CMAKE_BIN_PATH}:${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/emulator:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${PATH}
+ENV PATH=${RBENV_ROOT}/shims:${CMAKE_BIN_PATH}:${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/emulator:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${PATH}
 
 # Install system dependencies
 RUN apt update -qq && apt install -qq -y --no-install-recommends \
@@ -52,7 +52,7 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
         ninja-build \
         zip \
         # Dev dependencies required by Ruby
-        libtool \
+        libssl-dev \
         libyaml-dev \
         libz-dev \
         # Dev libraries requested by Hermes
@@ -63,9 +63,9 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*;
 
 # install ruby using rbenv
-RUN git clone https://github.com/rbenv/rbenv.git ${RBENV_PATH} \
-    && git clone https://github.com/rbenv/ruby-build.git ${RBENV_PATH}/plugins/ruby-build \
-    && eval "$(${RBENV_PATH}/bin/rbenv init -)" \
+RUN git clone https://github.com/rbenv/rbenv.git ${RBENV_ROOT} \
+    && git clone https://github.com/rbenv/ruby-build.git ${RBENV_ROOT}/plugins/ruby-build \
+    && eval "$(${RBENV_ROOT}/bin/rbenv init -)" \
     && rbenv install $RUBY_VERSION \
     && rbenv global $RUBY_VERSION \
     && gem install bundler


### PR DESCRIPTION
First of all thank you for this project. Nice work!

Several days ago we stuck into problem with `pod install` command. It fails with segfault due to old Ruby. Ubuntu has Ruby 2.7.0 in apt list. It's very old ruby version. 

Also cocoapods and fastlane already support latest Ruby 3.2.2.
Here an example of latest Ruby installation via rbenv.