### PR TITLE
Bump Java 11 -> 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV ANDROID_HOME=/opt/android
 ENV ANDROID_SDK_ROOT=${ANDROID_HOME}
 ENV ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/$NDK_VERSION
 
-ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 ENV CMAKE_BIN_PATH=${ANDROID_HOME}/cmake/$CMAKE_VERSION/bin
 
 ENV PATH=${CMAKE_BIN_PATH}:${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/emulator:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${PATH}
@@ -38,7 +38,7 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
         libgl1 \
         libtcmalloc-minimal4 \
         make \
-        openjdk-11-jdk-headless \
+        openjdk-17-jdk-headless \
         openssh-client \
         patch \
         python3 \


### PR DESCRIPTION
Because of AGP 8, we now need JDK 17:
- https://github.com/facebook/react-native/pull/37019

This change is bumping the JDK version from 11 to 17 in the Docker container