### PR TITLE
Install both JDK 11 and 17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ defaults: &defaults
 aliases:
   - &build-docker
     name: Build Docker Image
-    no_output_timeout: 20m
+    no_output_timeout: 30m
     command: |
       docker build -t react-native-community/react-native .
       docker run --rm --name rn-env react-native-community/react-native bin/sh -c "npx envinfo"
@@ -36,6 +36,7 @@ jobs:
           command: git clone https://github.com/facebook/react-native.git
       - run:
           name: Build React Native
+          no_output_timeout: 30m
           command: docker run --rm --ulimit nofile=10240 -v "$(pwd)/scripts/":/scripts -v "$(pwd)/react-native/":/react-native -w /react-native react-native-community/react-native /bin/sh -c "/scripts/test-react-native-setup.sh"
 
 workflows:

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
         libgl1 \
         libtcmalloc-minimal4 \
         make \
+        # React Native compiles with JDK 11, RN Tester & template with JDK 17
+        openjdk-11-jdk-headless \
         openjdk-17-jdk-headless \
         openssh-client \
         patch \


### PR DESCRIPTION
I'm working on AGP 8.x bump for React Native.

We're currently having a harder time on bumping JDK to 17 for the whole project due to how we do testing (Mockito/PowerMock, etc.)

For the time being, we'll settle on running ReactAndroid on JDK 11, and app projects on JDK 17. Therefore we need both on the container