### PR TITLE
Do not install JDK 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,6 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
         libgl1 \
         libtcmalloc-minimal4 \
         make \
-        # React Native compiles with JDK 11, RN Tester & template with JDK 17
-        openjdk-11-jdk-headless \
         openjdk-17-jdk-headless \
         openssh-client \
         patch \


### PR DESCRIPTION
As we fully cleaned up all the JDK 11 usages in React Native, we can now skip its installation