### PR TITLE
Update config.yml to deploy on main (renamed from master)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,5 +46,5 @@ workflows:
       - deploy:
           filters:
             branches:
-              only: master
+              only: main
       - build


### PR DESCRIPTION
Deploy script is not running on merges to main as it was recently renamed from master to main. This PR updates the circleci config with the correct default branch name.