### PR TITLE
Update CircleCI machine image to use Ubuntu 22.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 defaults: &defaults
   machine:
-    image: ubuntu-2004:202201-02
+    image: ubuntu-2204:2024.01.2
   working_directory: ~/project
 
 aliases:


### PR DESCRIPTION
Update Ubuntu version so the same Ubuntu 22.04 version is used in CircleCI. GitHub Actions and Dockerfile.
`ubuntu-2004:202201-02` is deprecated (see screenshot)
![image](https://github.com/react-native-community/docker-android/assets/4456572/906f54c9-6e72-4234-a782-61a3e61a1bdc)
