### PR TITLE
changes gcc from gcc 13 to gcc-11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,10 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
         apt-transport-https \
         curl \
         file \
-        gcc \
+        gcc-11 \
+        g++-11 \
         git \
-        g++ \
         gnupg2 \
-        libc++1 \
         libgl1 \
         libtcmalloc-minimal4 \
         make \
@@ -56,7 +55,10 @@ RUN apt update -qq && apt install -qq -y --no-install-recommends \
         jq \
         shellcheck \
     && gem install bundler \
-    && rm -rf /var/lib/apt/lists/*;
+    && rm -rf /var/lib/apt/lists/* \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 110 \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 110
+
 
 # install nodejs using n
 RUN curl -L https://raw.githubusercontent.com/tj/n/master/bin/n -o n \


### PR DESCRIPTION
new default gcc in ubuntu 24.04 introduces new c++ standard (c++18) which is not compatible with react-native c++ code.

Until react-native code will be updated to be able to compile with latest c++18 standard let's use old gcc-11.