### PR TITLE
Pre-download React Native native C++ dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,5 +83,18 @@ RUN curl -sS https://dl.google.com/android/repository/${SDK_VERSION} -o /tmp/sdk
     && rm -rf ${ANDROID_HOME}/.android \
     && chmod 777 -R /opt/android
 
+# Pre-download React Native native C++ dependencies so Gradle skips downloading them at build time
+RUN mkdir -p /opt/react-native-downloads \
+    && curl -sL -o /opt/react-native-downloads/boost_1_83_0.tar.gz https://archives.boost.io/release/1.83.0/source/boost_1_83_0.tar.gz \
+    && curl -sL -o /opt/react-native-downloads/double-conversion-1.1.6.tar.gz https://github.com/google/double-conversion/archive/v1.1.6.tar.gz \
+    && curl -sL -o /opt/react-native-downloads/fast_float-8.0.0.tar.gz https://github.com/fastfloat/fast_float/archive/v8.0.0.tar.gz \
+    && curl -sL -o /opt/react-native-downloads/fmt-11.0.2.tar.gz https://github.com/fmtlib/fmt/archive/11.0.2.tar.gz \
+    && curl -sL -o /opt/react-native-downloads/folly-2024.11.18.00.tar.gz https://github.com/facebook/folly/archive/v2024.11.18.00.tar.gz \
+    && curl -sL -o /opt/react-native-downloads/gflags-2.2.0.tar.gz https://github.com/gflags/gflags/archive/v2.2.0.tar.gz \
+    && curl -sL -o /opt/react-native-downloads/glog-0.3.5.tar.gz https://github.com/google/glog/archive/v0.3.5.tar.gz \
+    && curl -sL -o /opt/react-native-downloads/nlohmann_json-3.11.2.tar.gz https://github.com/nlohmann/json/archive/v3.11.2.tar.gz
+
+ENV REACT_NATIVE_DOWNLOADS_DIR=/opt/react-native-downloads
+
 # Disable git safe directory check as this is causing GHA to fail on GH Runners
 RUN git config --global --add safe.directory '*'

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,10 @@ ENV CMAKE_BIN_PATH=${ANDROID_HOME}/cmake/$CMAKE_VERSION/bin
 
 ENV PATH=${CMAKE_BIN_PATH}:${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/emulator:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${PATH}
 
+# Set the encoding to resolve a known character encoding issue with decompressing tar.gz files in containers
+# via Gradle: https://github.com/gradle/gradle/issues/23391#issuecomment-1878979127
+ENV LC_ALL=C.UTF8
+
 # Install system dependencies
 RUN apt update -qq && apt install -qq -y --no-install-recommends \
         apt-transport-https \


### PR DESCRIPTION
This should reduce flakyness of the build on facebook/react-native by prewarming a lot of native dependencies.